### PR TITLE
Implemented a function for returning all files in a directory tree as Path objects

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,9 @@
+import os
+import pathlib
+
+
+def walk_files(target, topdown=False):
+    """Returns Path objects of all files in a directory and it's subdirectories."""
+    for root, _, files in os.walk(target, topdown=topdown):
+       for name in files:
+            yield pathlib.Path(os.path.sep.join([root, name]))


### PR DESCRIPTION
This could form the basis of a function outlined in #2. This is a pretty standard implementation of [os.walk](https://docs.python.org/3/library/os.html#os.walk). The purpose is only to iterate over files so the second value of the tuples output by walk (the directory) goes unused and hence is assigned to `_`.

I have used `os.path.sep.join` instead of `os.path.join` as it is considerably more performant. Overall `walk_files` performs reasonably well taking around 2.5x the time of `os.walk`. I think this strikes a good balance between performance and ease of use, and can be optimised later.